### PR TITLE
Fix volume and fade envelope bitswap

### DIFF
--- a/RMW2_2_txt.py
+++ b/RMW2_2_txt.py
@@ -181,8 +181,8 @@ def cmdSetDutyArg(buffer:FileBuffer, text:RowText):
 
 def cmdSetBaseVolumeArg(buffer:FileBuffer, text:RowText):
     arg = buffer.read(offset=1)
-    vol = arg & 0xF
-    fade = arg>>4
+    vol = arg>>4        # fix the accidental fade and volume bits being swapped
+    fade = arg & 0xF
     #SORRY
     if CHANNELTYPE != ChannelType.WAVE:
         fadeText = ""


### PR DESCRIPTION
This fixes a rather small issue in which the program parsed the wrong bytes for the C2 command.

Before:
`6   |c2 c3   || Command set volume/envelope volume:3 fade:C (Fade in)`

After:
`6   |c2 c3   || Command set volume/envelope volume:C fade:3 (Fade out)`